### PR TITLE
C++ fixes

### DIFF
--- a/c.c
+++ b/c.c
@@ -77,7 +77,7 @@ typedef enum eKeywordId {
 	KEYWORD_LOCAL, KEYWORD_LONG,
 	KEYWORD_M_BAD_STATE, KEYWORD_M_BAD_TRANS, KEYWORD_M_STATE, KEYWORD_M_TRANS,
 	KEYWORD_MUTABLE,
-	KEYWORD_NAMESPACE, KEYWORD_NEW, KEYWORD_NEWCOV, KEYWORD_NATIVE,
+	KEYWORD_NAMESPACE, KEYWORD_NEW, KEYWORD_NEWCOV, KEYWORD_NATIVE, KEYWORD_NOEXCEPT,
 	KEYWORD_OPERATOR, KEYWORD_OUTPUT, KEYWORD_OVERLOAD, KEYWORD_OVERRIDE,
 	KEYWORD_PACKED, KEYWORD_PORT, KEYWORD_PACKAGE, KEYWORD_PRIVATE,
 	KEYWORD_PROGRAM, KEYWORD_PROTECTED, KEYWORD_PUBLIC,
@@ -419,6 +419,7 @@ static const keywordDesc KeywordTable [] = {
 	{ "native",         KEYWORD_NATIVE,         { 0, 0, 0, 1, 0 } },
 	{ "new",            KEYWORD_NEW,            { 0, 1, 1, 1, 0 } },
 	{ "newcov",         KEYWORD_NEWCOV,         { 0, 0, 0, 0, 1 } },
+	{ "noexcept",       KEYWORD_NOEXCEPT,       { 0, 1, 0, 0, 0 } },
 	{ "operator",       KEYWORD_OPERATOR,       { 0, 1, 1, 0, 0 } },
 	{ "output",         KEYWORD_OUTPUT,         { 0, 0, 0, 0, 1 } },
 	{ "overload",       KEYWORD_OVERLOAD,       { 0, 1, 0, 0, 0 } },
@@ -1967,6 +1968,7 @@ static boolean skipPostArgumentStuff (
 				case KEYWORD_NAMESPACE:
 				case KEYWORD_NEW:
 				case KEYWORD_NEWCOV:
+				case KEYWORD_NOEXCEPT:
 				case KEYWORD_OPERATOR:
 				case KEYWORD_OVERLOAD:
 				case KEYWORD_PRIVATE:

--- a/c.c
+++ b/c.c
@@ -83,7 +83,7 @@ typedef enum eKeywordId {
 	KEYWORD_PROGRAM, KEYWORD_PROTECTED, KEYWORD_PUBLIC,
 	KEYWORD_REGISTER, KEYWORD_RETURN,
 	KEYWORD_SHADOW, KEYWORD_STATE,
-	KEYWORD_SHORT, KEYWORD_SIGNED, KEYWORD_STATIC, KEYWORD_STRING,
+	KEYWORD_SHORT, KEYWORD_SIGNED, KEYWORD_STATIC, KEYWORD_STATIC_ASSERT, KEYWORD_STRING,
 	KEYWORD_STRUCT, KEYWORD_SWITCH, KEYWORD_SYNCHRONIZED,
 	KEYWORD_TASK, KEYWORD_TEMPLATE, KEYWORD_THIS, KEYWORD_THROW,
 	KEYWORD_THROWS, KEYWORD_TRANSIENT, KEYWORD_TRANS, KEYWORD_TRANSITION,
@@ -437,6 +437,7 @@ static const keywordDesc KeywordTable [] = {
 	{ "signed",         KEYWORD_SIGNED,         { 1, 1, 0, 0, 0 } },
 	{ "state",          KEYWORD_STATE,          { 0, 0, 0, 0, 1 } },
 	{ "static",         KEYWORD_STATIC,         { 1, 1, 1, 1, 1 } },
+	{ "static_assert",  KEYWORD_STATIC_ASSERT,  { 0, 1, 0, 0, 0} },
 	{ "string",         KEYWORD_STRING,         { 0, 0, 1, 0, 1 } },
 	{ "struct",         KEYWORD_STRUCT,         { 1, 1, 1, 0, 0 } },
 	{ "switch",         KEYWORD_SWITCH,         { 1, 1, 1, 1, 0 } },
@@ -1764,6 +1765,7 @@ static void processToken (tokenInfo *const token, statementInfo *const st)
 		case KEYWORD_RETURN:    skipStatement (st);                     break;
 		case KEYWORD_SHORT:     st->declaration = DECL_BASE;            break;
 		case KEYWORD_SIGNED:    st->declaration = DECL_BASE;            break;
+		case KEYWORD_STATIC_ASSERT:   skipParens();                     break;
 		case KEYWORD_STRING:    st->declaration = DECL_BASE;            break;
 		case KEYWORD_STRUCT:    st->declaration = DECL_STRUCT;          break;
 		case KEYWORD_TASK:      st->declaration = DECL_TASK;            break;


### PR DESCRIPTION
These three commits resolve https://github.com/arduino/arduino-builder/issues/68 by fixing
- static_assert
- noexcept
- final
- override

These changes were copied from [geany repository](https://github.com/geany/geany/commits/master/tagmanager/ctags/c.c). Individual commits in this pull request contain links to the original commits in geany tree.
