### PR TITLE
Fix C++11 classed enums and enums with type specifiers

### DIFF
--- a/c.c
+++ b/c.c
@@ -1725,6 +1725,12 @@ static void processInterface (statementInfo *const st)
 	st->declaration = DECL_INTERFACE;
 }
 
+static void checkIsClassEnum (statementInfo *const st, const declType decl)
+{
+	if (! isLanguage (Lang_cpp) || st->declaration != DECL_ENUM)
+		st->declaration = decl;
+}
+
 static void processToken (tokenInfo *const token, statementInfo *const st)
 {
 	switch (token->keyword)        /* is it a reserved word? */
@@ -1740,7 +1746,7 @@ static void processToken (tokenInfo *const token, statementInfo *const st)
 		case KEYWORD_BIT:       st->declaration = DECL_BASE;            break;
 		case KEYWORD_CATCH:     skipParens (); skipBraces ();           break;
 		case KEYWORD_CHAR:      st->declaration = DECL_BASE;            break;
-		case KEYWORD_CLASS:     st->declaration = DECL_CLASS;           break;
+		case KEYWORD_CLASS:     checkIsClassEnum (st, DECL_CLASS);      break;
 		case KEYWORD_CONST:     st->declaration = DECL_BASE;            break;
 		case KEYWORD_DOUBLE:    st->declaration = DECL_BASE;            break;
 		case KEYWORD_ENUM:      st->declaration = DECL_ENUM;            break;
@@ -1768,7 +1774,7 @@ static void processToken (tokenInfo *const token, statementInfo *const st)
 		case KEYWORD_SIGNED:    st->declaration = DECL_BASE;            break;
 		case KEYWORD_STATIC_ASSERT:   skipParens();                     break;
 		case KEYWORD_STRING:    st->declaration = DECL_BASE;            break;
-		case KEYWORD_STRUCT:    st->declaration = DECL_STRUCT;          break;
+		case KEYWORD_STRUCT:    checkIsClassEnum (st, DECL_STRUCT);     break;
 		case KEYWORD_TASK:      st->declaration = DECL_TASK;            break;
 		case KEYWORD_THROWS:    discardTypeList (token);                break;
 		case KEYWORD_UNION:     st->declaration = DECL_UNION;           break;

--- a/c.c
+++ b/c.c
@@ -2528,6 +2528,15 @@ static void processColon (statementInfo *const st)
 			else if (c == ';')
 				setToken (st, TOKEN_SEMICOLON);
 		}
+		else if (isLanguage (Lang_cpp) && st->declaration == DECL_ENUM)
+		{
+			/* skip enum's base type */
+			c = skipToOneOf ("{;");
+			if (c == '{')
+				setToken (st, TOKEN_BRACE_OPEN);
+			else if (c == ';')
+				setToken (st, TOKEN_SEMICOLON);
+		}
 		else
 		{
 			const tokenInfo *const prev  = prevToken (st, 1);


### PR DESCRIPTION
Manual cherry-pick of
- https://github.com/geany/geany/commit/f2f22d34ab9063852279bc6c5a45c8d3cfafdc0a
- https://github.com/geany/geany/commit/6c7f69578d8e142f5994cc9cf0e0abc83a606a1b

Fixes [build issue](https://travis-ci.org/esp8266/Arduino/builds/107013112) found when using DNSServer library. ctags is getting confused due to the use of classed enums: https://github.com/esp8266/Arduino/blob/master/libraries/DNSServer/src/DNSServer.h#L9
