### PR TITLE
fix crash with templates containing shifts

### DIFF
--- a/c.c
+++ b/c.c
@@ -1414,6 +1414,16 @@ static void skipToMatch (const char *const pair)
 				break;
 			}
 		}
+		/* early out if matching "<>" and we encounter a ";" or "{" to mitigate
+		 * match problems with C++ generics containing a static expression like
+		 *     foo<X<Y> bar;
+		 * normally neither ";" nor "{" could appear inside "<>" anyway. */
+		else if (isLanguage (Lang_cpp) && begin == '<' &&
+		         (c == ';' || c == '{'))
+		{
+			cppUngetc (c);
+			break;
+		}
 	}
 	if (c == EOF)
 	{

--- a/c.c
+++ b/c.c
@@ -1388,10 +1388,16 @@ static void skipToMatch (const char *const pair)
 	{
 		if (CollectingSignature)
 			vStringPut (Signature, c);
-		
 
 		if (c == begin)
 		{
+			char s = cppGetc();
+			if (s == '<' && s == c) {
+				// templates can still contain "<<" ot "<<="
+				break;
+			} else {
+				cppUngetc(s);
+			}
 			++matchLevel;
 			if (braceFormatting  &&  getDirectiveNestLevel () != initialLevel)
 			{


### PR DESCRIPTION
twin commit: https://github.com/arduino/arduino-builder/pull/118
