### PR TITLE
Handle << and >> in expressions in template parameter lists

### DIFF
--- a/c.c
+++ b/c.c
@@ -1392,20 +1392,34 @@ static void skipToMatch (const char *const pair)
 
 		if (c == begin)
 		{
-			++matchLevel;
-			if (braceFormatting  &&  getDirectiveNestLevel () != initialLevel)
-			{
-				skipToFormattedBraceMatch ();
-				break;
+			// watch out for '<<' in template arguments
+			int x = cppGetc ();
+			if(c == '<' && x == '<') { 
+				// we've found a << - do nothing
+			} else {
+				cppUngetc (x);
+				++matchLevel;
+				if (braceFormatting  &&  getDirectiveNestLevel () != initialLevel)
+				{
+					skipToFormattedBraceMatch ();
+					break;
+				}
 			}
 		}
 		else if (c == end)
 		{
-			--matchLevel;
-			if (braceFormatting  &&  getDirectiveNestLevel () != initialLevel)
-			{
-				skipToFormattedBraceMatch ();
-				break;
+			// watch out for '>>' in template arguments
+			int x = cppGetc ();
+			if(c == '>' && x == '>') { 
+				// we've found a >> in a template - skip it
+			} else {
+				cppUngetc (x);
+				--matchLevel;
+				if (braceFormatting  &&  getDirectiveNestLevel () != initialLevel)
+				{
+					skipToFormattedBraceMatch ();
+					break;
+				}
 			}
 		}
 	}

--- a/c.c
+++ b/c.c
@@ -1395,7 +1395,9 @@ static void skipToMatch (const char *const pair)
 			// watch out for '<<' in template arguments
 			int x = cppGetc ();
 			if(c == '<' && x == '<') { 
-				// we've found a << - do nothing
+				// we've found a << - do nothing except record the signature
+				if (CollectingSignature)
+					vStringPut(Signature, x);
 			} else {
 				cppUngetc (x);
 				++matchLevel;
@@ -1411,7 +1413,9 @@ static void skipToMatch (const char *const pair)
 			// watch out for '>>' in template arguments
 			int x = cppGetc ();
 			if(c == '>' && x == '>') { 
-				// we've found a >> in a template - skip it
+				// we've found a >> - do nothing except record the signature
+				if (CollectingSignature)
+					vStringPut(Signature, x);
 			} else {
 				cppUngetc (x);
 				--matchLevel;


### PR DESCRIPTION
Fix for arduino/arduino-builder#120 - handle << and >> expressions inside of template parameter lists. 
