### PR TITLE
fix: support for parsing escaped #line tags

### DIFF
--- a/read.c
+++ b/read.c
@@ -164,6 +164,9 @@ static vString *readFileName (void)
 	while (c != EOF  &&  c != '\n'  &&
 			(quoteDelimited ? (c != '"') : (c != ' '  &&  c != '\t')))
 	{
+		if (c == '\\') {
+			c = getc (File.fp);
+		}
 		vStringPut (fileName, c);
 		c = getc (File.fp);
 	}


### PR DESCRIPTION
Previously `#line` tags were not correctly parsed if they contained escaped chars like `\"`

```
$ cat /tmp/test.cpp
# 1 "/home/megabug/Workspace/arduino-cli/internal/integrationtest/testdata/PathWith\"Quotes/Sketch/Sketch.ino"
void setup() {
  foo();
}
void loop() {}
void foo() {}
$ ./ctags -u --language-force=c++ -f - --c++-kinds=svpf --fields=KSTtzns --line-directives /tmp/test.cpp
$
```

after this patch the line directives are parsed correctly:

```
$ cat /tmp/test.cpp
# 1 "/home/megabug/Workspace/arduino-cli/internal/integrationtest/testdata/PathWith\"Quotes/Sketch/Sketch.ino"
void setup() {
  foo();
}
void loop() {}
void foo() {}
$ ./ctags -u --language-force=c++ -f - --c++-kinds=svpf --fields=KSTtzns --line-directives /tmp/test.cpp
setup	/home/megabug/Workspace/arduino-cli/internal/integrationtest/testdata/PathWith"Quotes/Sketch/Sketch.ino	/^void setup() {$/;"	kind:function	line:1	signature:()	returntype:void
loop	/home/megabug/Workspace/arduino-cli/internal/integrationtest/testdata/PathWith"Quotes/Sketch/Sketch.ino	/^void loop() {}$/;"	kind:function	line:4	signature:()	returntype:void
foo	/home/megabug/Workspace/arduino-cli/internal/integrationtest/testdata/PathWith"Quotes/Sketch/Sketch.ino	/^void foo() {}$/;"	kind:function	line:5	signature:()	returntype:void
$
```
